### PR TITLE
Ремонтируем столкновения

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,16 +21,13 @@ class Car(pygame.sprite.Sprite):
         self.image = pygame.image.load(f'spirities/tazy/{name}')
         self.image = pygame.transform.scale(self.image, (200, 100))  # уменьшаем изображение
         self.image = pygame.transform.rotate(self.image, 180)
-
         self.rect = self.image.get_rect()
-        self.rect.topleft = 20, 205
-        surf = pygame.Surface((self.image.get_width(), self.image.get_height()))  # не работает
+        surf = pygame.Surface((self.rect.w, self.rect.h), pygame.SRCALPHA)
         x1, y1, x2, y2 = self.image.get_rect()
-        print(x1, x2, y1, y2)
-
         pygame.draw.rect(surf, 'white',
                          (x1 + 30, y1 + 30, x2 - 30, y2 - 30))  # тут фигня с модернизированной коллизией
         self.mask = pygame.mask.from_surface(surf)
+        self.rect.topleft = 20, 205
 
         self.get_configurations()
 
@@ -57,7 +54,7 @@ class Car(pygame.sprite.Sprite):
         global traffic_speed, road_speed
         keys = pygame.key.get_pressed()
         for trafs in traffic_sprites:  # не работает
-            if pygame.sprite.collide_mask(car, trafs):
+            if pygame.sprite.collide_mask(self, trafs):
                 terminate()
         # if pygame.sprite.groupcollide(main_sprites, traffic_sprites, True, False):
         #     sys.exit()
@@ -85,7 +82,7 @@ class Traffic_car(pygame.sprite.Sprite):
         super(Traffic_car, self).__init__(*groups)
         self.image = Traffic_car.image
         self.rect = self.image.get_rect()
-        surf = pygame.Surface((self.image.get_width(), self.image.get_height()))  # не работает
+        surf = pygame.Surface((self.rect.w, self.rect.h), pygame.SRCALPHA)
         x1, y1, x2, y2 = self.image.get_rect()
         pygame.draw.rect(surf, 'white', (x1 + 30, y1 + 30, x2 - 30, y2 - 30))
         self.mask = pygame.mask.from_surface(surf)


### PR DESCRIPTION
pygame.mask.from_surface делает маску из непрозрачных пикселей, поэтому поверхность нужно сделать изначально прозрачной - pygame.SRCALPHA